### PR TITLE
Adding MarkdownString and renaming Markdown to MarkdownFile

### DIFF
--- a/BlazorMarkdown/Markdown.cs
+++ b/BlazorMarkdown/Markdown.cs
@@ -3,12 +3,14 @@
 using Markdig;
 using Microsoft.AspNetCore.Components;
 using Microsoft.AspNetCore.Components.Rendering;
+using System;
 
 namespace BlazorMarkdown
 {
     /// <summary>
     /// A Component for displaying Markdown.
     /// </summary>
+    [Obsolete]
     public class Markdown : MarkdownFile {
     }
 }

--- a/BlazorMarkdown/Markdown.cs
+++ b/BlazorMarkdown/Markdown.cs
@@ -1,4 +1,5 @@
 ﻿using System.IO;
+
 using Markdig;
 using Microsoft.AspNetCore.Components;
 using Microsoft.AspNetCore.Components.Rendering;
@@ -8,37 +9,6 @@ namespace BlazorMarkdown
     /// <summary>
     /// A Component for displaying Markdown.
     /// </summary>
-    public class Markdown : ComponentBase
-    {
-        /// <summary>
-        /// Gets or sets the path to the Markdown file.
-        /// </summary>
-        [Parameter]
-        public string FilePath { get; set; }
-
-        private MarkupString _markupString = new MarkupString();
-
-        /// <summary>
-        /// Gets the <see cref="MarkdownPipeline"/> to use.
-        /// </summary>
-        public virtual MarkdownPipeline Pipeline => new MarkdownPipelineBuilder()
-            .UseEmojiAndSmiley()
-            .UseAdvancedExtensions()
-            .Build();
-
-        /// <inheritdoc/>
-        protected override void BuildRenderTree(RenderTreeBuilder builder)
-        {
-            base.BuildRenderTree(builder);
-            builder.AddContent(0, _markupString);
-        }
-
-        /// <inheritdoc/>
-        protected override void OnParametersSet()
-        {
-            base.OnParametersSet();
-            var markdown = File.ReadAllText(FilePath);
-            _markupString = new MarkupString(Markdig.Markdown.ToHtml(markdown, Pipeline));
-        }
+    public class Markdown : MarkdownFile {
     }
 }

--- a/BlazorMarkdown/MarkdownFile.cs
+++ b/BlazorMarkdown/MarkdownFile.cs
@@ -1,0 +1,45 @@
+﻿using System.IO;
+
+using Markdig;
+using Microsoft.AspNetCore.Components;
+using Microsoft.AspNetCore.Components.Rendering;
+
+namespace BlazorMarkdown
+{
+    /// <summary>
+    /// A Component for displaying Markdown.
+    /// </summary>
+    public class MarkdownFile : ComponentBase
+    {
+        /// <summary>
+        /// Gets or sets the path to the Markdown file.
+        /// </summary>
+        [Parameter]
+        public string FilePath { get; set; }
+
+        private MarkupString _markupString = new MarkupString();
+
+        /// <summary>
+        /// Gets the <see cref="MarkdownPipeline"/> to use.
+        /// </summary>
+        public virtual MarkdownPipeline Pipeline => new MarkdownPipelineBuilder()
+            .UseEmojiAndSmiley()
+            .UseAdvancedExtensions()
+            .Build();
+
+        /// <inheritdoc/>
+        protected override void BuildRenderTree(RenderTreeBuilder builder)
+        {
+            base.BuildRenderTree(builder);
+            builder.AddContent(0, _markupString);
+        }
+
+        /// <inheritdoc/>
+        protected override void OnParametersSet()
+        {
+            base.OnParametersSet();
+            var markdown = File.ReadAllText(FilePath);
+            _markupString = new MarkupString(Markdig.Markdown.ToHtml(markdown, Pipeline));
+        }
+    }
+}

--- a/BlazorMarkdown/MarkdownString.cs
+++ b/BlazorMarkdown/MarkdownString.cs
@@ -1,0 +1,44 @@
+﻿using System.IO;
+
+using Markdig;
+using Microsoft.AspNetCore.Components;
+using Microsoft.AspNetCore.Components.Rendering;
+
+namespace BlazorMarkdown
+{
+    /// <summary>
+    /// A Component for displaying Markdown.
+    /// </summary>
+    public class MarkdownString : ComponentBase
+    {
+        /// <summary>
+        /// Gets or sets the path to the Markdown file.
+        /// </summary>
+        [Parameter]
+        public string Markdown { get; set; }
+
+        private MarkupString _markupString = new MarkupString();
+
+        /// <summary>
+        /// Gets the <see cref="MarkdownPipeline"/> to use.
+        /// </summary>
+        public virtual MarkdownPipeline Pipeline => new MarkdownPipelineBuilder()
+            .UseEmojiAndSmiley()
+            .UseAdvancedExtensions()
+            .Build();
+
+        /// <inheritdoc/>
+        protected override void BuildRenderTree(RenderTreeBuilder builder)
+        {
+            base.BuildRenderTree(builder);
+            builder.AddContent(0, _markupString);
+        }
+
+        /// <inheritdoc/>
+        protected override void OnParametersSet()
+        {
+            base.OnParametersSet();
+            _markupString = new MarkupString(Markdig.Markdown.ToHtml(Markdown, Pipeline));
+        }
+    }
+}

--- a/README.md
+++ b/README.md
@@ -32,13 +32,26 @@ Add the following to your `_Imports.razor`
 ```
 
 ## Usage
-The `Markdown` component takes the path to a Markdown file in the `FilePath` parameter. The component will convert the Markdown file to HTML in place of the component.
+
+### Markdown file
+The `MarkdownFile` component takes the path to a Markdown file in the `FilePath` parameter. The component will convert the Markdown file to HTML in place of the component.
 
 ```html
-<Markdown FilePath="wwwroot/markdown-file.md" />
+<MarkdownFile FilePath="wwwroot/markdown-file.md" />
 ```
 > **Tip:** :bulb:
 > If you put your Markdown files outside of the wwwroot folder then you need to ensure they are copied to the output directory (select properties on the file from within Visual Studio).
+
+### MarkdownString
+The `MarkdownString` component takes a raw markdown string with the `Markdown` parameter and converts it into HTML that is placed inside the component.
+
+```html
+<MarkdownString Markdown='@MarkdownString'>
+
+@code{
+    string MarkdownString = "# Headline"
+}
+```
 
 ## Additional options
 Blazor Markdown uses [Markdig](https://github.com/lunet-io/markdig) under the hood. Markdig has different [extensions](https://github.com/lunet-io/markdig/blob/master/src/Markdig/MarkdownExtensions.cs) that you can configure. For this reason the Pipeline property is overridable on the Markdown component.


### PR DESCRIPTION
I added the MarkdownString component for the case that you get the Markdown from another source like a Database.
To make it clearer which one is used I renamed the Markdown component to MarkdownFile. 

I didn't want to make breaking changes so the Markdown component now inherits from the MarkdownFile component, that way it can be used the same way as before but it is marked as obsolete.